### PR TITLE
Replenish that Prefix is also for logs

### DIFF
--- a/resources/config.yml
+++ b/resources/config.yml
@@ -1,7 +1,7 @@
 # SlapperRotation
 # Updated Version for API 4.0.0 PocketMine-MP
 
-# Message Prefix
+# Message and Log Prefix
 prefix: "§7[§eSlapperRotation§7] "
 
 # Max Distance Between Slapper to player.


### PR DESCRIPTION
PluginBase->getLogger() has the plugin name as prefix by default. But since your plugin has custom prefix, I understand why you had decided to use Server->getLogger() instead of the one from above.

So I’d suggest telling the user that Prefix is also used in logs.